### PR TITLE
Fix batch emailing

### DIFF
--- a/app/notifiers/broadcast_notifier.rb
+++ b/app/notifiers/broadcast_notifier.rb
@@ -9,7 +9,7 @@ class BroadcastNotifier < Notifier
 
   def notify(email_recipients)
     unless email_recipients.empty?
-      Delayed::Job.enqueue BroadcastJob.new(email_recipients, post)
+      BatchNotificationSender.delay.deliver(:broadcast_email, email_recipients, post)
     end
   end
 
@@ -20,13 +20,5 @@ class BroadcastNotifier < Notifier
       map(&:user).
       select { |u| Ability.new(u).can? :read, post }.
       to_set
-  end
-
-private
-  BroadcastJob = Struct.new(:email_recipients, :post) do
-    def perform
-      mail = NotificationMailer.broadcast_email(email_recipients, post)
-      BatchMailSender.new(mail).delay.deliver
-    end
   end
 end

--- a/app/notifiers/subforum_subscription_notifier.rb
+++ b/app/notifiers/subforum_subscription_notifier.rb
@@ -9,19 +9,11 @@ class SubforumSubscriptionNotifier < Notifier
 
   def notify(email_recipients)
     unless email_recipients.empty?
-      Delayed::Job.enqueue SubforumSubscriptionJob.new(email_recipients, thread)
+      BatchNotificationSender.delay.deliver(:new_thread_in_subscribed_subforum_email, email_recipients, thread)
     end
   end
 
   def possible_recipients
     @possible_recipients ||= thread.subforum.subscribers.select { |u| Ability.new(u).can? :read, thread }.to_set
-  end
-
-private
-  SubforumSubscriptionJob = Struct.new(:email_recipients, :thread) do
-    def perform
-      mail = NotificationMailer.new_thread_in_subscribed_subforum_email(email_recipients, thread)
-      BatchMailSender.new(mail).deliver
-    end
   end
 end

--- a/app/notifiers/thread_subscription_notifier.rb
+++ b/app/notifiers/thread_subscription_notifier.rb
@@ -9,19 +9,11 @@ class ThreadSubscriptionNotifier < Notifier
 
   def notify(email_recipients)
     unless email_recipients.empty?
-      Delayed::Job.enqueue ThreadSubscriptionJob.new(email_recipients, post)
+      BatchNotificationSender.delay.deliver(:new_post_in_subscribed_thread_email, email_recipients, post)
     end
   end
 
   def possible_recipients
     @possible_recipients ||= post.thread.subscribers.select { |u| Ability.new(u).can? :read, post }.to_set
-  end
-
-private
-  ThreadSubscriptionJob = Struct.new(:email_recipients, :post) do
-    def perform
-      mail = NotificationMailer.new_post_in_subscribed_thread_email(email_recipients, post)
-      BatchMailSender.new(mail).deliver
-    end
   end
 end

--- a/app/services/batch_notification_sender.rb
+++ b/app/services/batch_notification_sender.rb
@@ -1,0 +1,6 @@
+class BatchNotificationSender
+  def self.deliver(method, *args, &block)
+    mail = NotificationMailer.send(method, *args, &block)
+    BatchMailSender.new(mail).deliver
+  end
+end


### PR DESCRIPTION
`mail` wasn't being serialized correctly by DelayedJob, causing `mail.from` to be `[nil]` when the API call is ultimately made.
