### PR TITLE
Only send subscription emails when subscribed is true

### DIFF
--- a/app/models/concerns/subscribable.rb
+++ b/app/models/concerns/subscribable.rb
@@ -6,7 +6,7 @@ module Subscribable
   end
 
   def subscribers
-    User.where(id: subscriptions.where(subscribed: true).map(&:user_id))
+    User.where(id: subscriptions.where(subscribed: true).select(:user_id))
   end
 
   def subscription_for(user)


### PR DESCRIPTION
We were sending email notifications to all users for which a subscription existed, regardless of whether `subscribed` was true.
