### PR TITLE
Monitor connection count in production

### DIFF
--- a/config/initializers/connection_monitor.rb
+++ b/config/initializers/connection_monitor.rb
@@ -1,0 +1,34 @@
+module ConnectionMonitor
+  CONNECTIONS = {}
+
+  def checkout
+    conn = super
+    CONNECTIONS[conn.object_id] = caller
+
+    if CONNECTIONS.size > 3 # we should have a max of 3 connections per-process, so log if we ever have more
+      puts_formatted_error
+    end
+
+    conn
+  end
+
+  def checkin(conn)
+    CONNECTIONS.delete(conn.object_id)
+    super
+  end
+
+private
+  def puts_formatted_error
+    Rails.logger.error "DB per-process connection limit exceeded: #{CONNECTIONS.count}"
+    CONNECTIONS.each do |k, caller_stack|
+      Rails.logger.error '='*80
+      Rails.logger.error caller_stack.join("\n")
+    end
+  end
+end
+
+if Rails.env.production?
+  class ActiveRecord::ConnectionAdapters::ConnectionPool
+    prepend ConnectionMonitor
+  end
+end


### PR DESCRIPTION
The idea here is that, according to our reasoning, we should never have more than 3 checked out DB connections at once per process: two threads running in a Puma worker plus one pubsub thread. This connection monitor logs an error whenever more than 3 connections are checked out, including the call stacks when each connection was checked out so that we can hopefully diagnose which parts of the app are checking out additional connections.

A corresponding Papertrail search will need to be set up to notify us when we have > 3 connections.
