### PR TITLE
Include "Community" in Reply-To field

### DIFF
--- a/app/controllers/concerns/email_fields.rb
+++ b/app/controllers/concerns/email_fields.rb
@@ -6,6 +6,10 @@ module EmailFields
   end
 
   def reply_to_field(reply_info)
-    "reply-#{reply_info}@mail.community.hackerschool.com"
+    "Community <reply-#{reply_info}@mail.community.hackerschool.com>"
+  end
+
+  def subject_field(thread)
+    "[Community - #{thread.subforum.name}] #{thread.title}"
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -58,9 +58,4 @@ class NotificationMailer < ActionMailer::Base
          from: from_field(@thread.created_by.name),
          subject: subject_field(@thread))
   end
-
-private
-  def subject_field(thread)
-    "[Community - #{thread.subforum.name}] #{thread.title}"
-  end
 end


### PR DESCRIPTION
I'm hoping this makes it more obvious that you're replying to Community, not to an individual.
