### PR TITLE
Remove thread.pinned in a migration

### DIFF
--- a/db/migrate/20140903171050_remove_accidental_pinned_attribute.rb
+++ b/db/migrate/20140903171050_remove_accidental_pinned_attribute.rb
@@ -1,0 +1,77 @@
+class RemoveAccidentalPinnedAttribute < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+DROP VIEW threads_with_visited_status;
+
+CREATE VIEW threads_with_visited_status AS
+ SELECT thread_users.id,
+    thread_users.title,
+    thread_users.subforum_id,
+    thread_users.created_by_id,
+    thread_users.created_at,
+    thread_users.updated_at,
+    thread_users.highest_post_number,
+    thread_users.user_id,
+        CASE
+            WHEN (visited_statuses.last_post_number_read IS NULL) THEN 0
+            ELSE visited_statuses.last_post_number_read
+        END AS last_post_number_read,
+        CASE
+            WHEN (visited_statuses.last_post_number_read IS NULL) THEN true
+            ELSE (visited_statuses.last_post_number_read < thread_users.highest_post_number)
+        END AS unread
+   FROM (( SELECT discussion_threads.id,
+            discussion_threads.title,
+            discussion_threads.subforum_id,
+            discussion_threads.created_by_id,
+            discussion_threads.created_at,
+            discussion_threads.updated_at,
+            discussion_threads.highest_post_number,
+            users.id AS user_id
+           FROM discussion_threads,
+            users) thread_users
+   LEFT JOIN visited_statuses ON (((thread_users.id = visited_statuses.thread_id) AND ((thread_users.user_id = visited_statuses.user_id) OR (visited_statuses.user_id IS NULL)))));
+SQL
+
+    remove_column :discussion_threads, :pinned
+  end
+
+  def down
+    add_column :discussion_threads, :pinned, :boolean, default: false
+
+    execute <<-SQL
+DROP VIEW threads_with_visited_status;
+
+CREATE VIEW threads_with_visited_status AS
+ SELECT thread_users.id,
+    thread_users.title,
+    thread_users.subforum_id,
+    thread_users.created_by_id,
+    thread_users.created_at,
+    thread_users.updated_at,
+    thread_users.pinned,
+    thread_users.highest_post_number,
+    thread_users.user_id,
+        CASE
+            WHEN (visited_statuses.last_post_number_read IS NULL) THEN 0
+            ELSE visited_statuses.last_post_number_read
+        END AS last_post_number_read,
+        CASE
+            WHEN (visited_statuses.last_post_number_read IS NULL) THEN true
+            ELSE (visited_statuses.last_post_number_read < thread_users.highest_post_number)
+        END AS unread
+   FROM (( SELECT discussion_threads.id,
+            discussion_threads.title,
+            discussion_threads.subforum_id,
+            discussion_threads.created_by_id,
+            discussion_threads.created_at,
+            discussion_threads.updated_at,
+            discussion_threads.pinned,
+            discussion_threads.highest_post_number,
+            users.id AS user_id
+           FROM discussion_threads,
+            users) thread_users
+   LEFT JOIN visited_statuses ON (((thread_users.id = visited_statuses.thread_id) AND ((thread_users.user_id = visited_statuses.user_id) OR (visited_statuses.user_id IS NULL)))));
+SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -79,7 +79,6 @@ CREATE TABLE discussion_threads (
     created_by_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    pinned boolean DEFAULT false,
     highest_post_number integer DEFAULT 0
 );
 
@@ -444,7 +443,6 @@ CREATE VIEW threads_with_visited_status AS
     thread_users.created_by_id,
     thread_users.created_at,
     thread_users.updated_at,
-    thread_users.pinned,
     thread_users.highest_post_number,
     thread_users.user_id,
         CASE
@@ -461,7 +459,6 @@ CREATE VIEW threads_with_visited_status AS
             discussion_threads.created_by_id,
             discussion_threads.created_at,
             discussion_threads.updated_at,
-            discussion_threads.pinned,
             discussion_threads.highest_post_number,
             users.id AS user_id
            FROM discussion_threads,
@@ -834,4 +831,6 @@ INSERT INTO schema_migrations (version) VALUES ('20140820161336');
 INSERT INTO schema_migrations (version) VALUES ('20140820175446');
 
 INSERT INTO schema_migrations (version) VALUES ('20140826193115');
+
+INSERT INTO schema_migrations (version) VALUES ('20140903171050');
 


### PR DESCRIPTION
Migration runs fine on current prod db.
