### PR TITLE
Send emails from the user, but include list headers so that reply-all works

### DIFF
--- a/app/controllers/concerns/email_fields.rb
+++ b/app/controllers/concerns/email_fields.rb
@@ -9,8 +9,12 @@ module EmailFields
     "[Community - #{thread.subforum.name}] #{thread.title}"
   end
 
+  def reply_to_community(reply_info)
+    "reply-#{reply_info}@mail.community.hackerschool.com"
+  end
+
   def list_post_field(reply_info)
-    "Community <reply-#{reply_info}@mail.community.hackerschool.com>"
+    "Community <#{reply_to_community(reply_info)}>"
   end
 
   def list_id_field

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -10,8 +10,6 @@ class NotificationMailer < ActionMailer::Base
 
     reply_info = ReplyInfoVerifier.generate(@user, @post)
 
-    headers["X-Mailgun-Variables"] = JSON.generate({reply_info: reply_info})
-
     if @post.previous_message_id
       headers["In-Reply-To"] = @post.previous_message_id
     end
@@ -21,8 +19,11 @@ class NotificationMailer < ActionMailer::Base
       to: @user.email,
       from: from_field(@mentioned_by),
       subject: subject_field(@post.thread),
+      reply_to: "#{list_post_field(reply_info)}, #{from_field(@mentioned_by)}",
       "List-ID" => list_id_field,
-      "List-Post" => list_post_field(reply_info)
+      "List-Post" => list_post_field(reply_info),
+      "Precedence" => "list",
+      "X-Mailgun-Variables" => JSON.generate({reply_info: reply_info})
     )
   end
 

--- a/app/services/batch_mail_sender.rb
+++ b/app/services/batch_mail_sender.rb
@@ -41,9 +41,11 @@ private
       "text" => mail.text_part.body.to_s,
       "html" => mail.html_part.body.to_s,
       "h:Message-ID" => mail.header["Message-ID"].to_s,
+      "h:Reply-To" => "#{list_post_field(reply_info)}, #{mail["from"].to_s}",
       "h:In-Reply-To" => mail.header["In-Reply-To"].to_s,
       "h:List-Post" => list_post_field("%recipient.reply_info%"),
       "h:List-ID" => list_id_field,
+      "h:Precedence" => "list",
       "v:reply_info" => "%recipient.reply_info%",
       "recipient-variables" => JSON.generate(recipient_variables)
     )


### PR DESCRIPTION
Fixes #164.

According to a website on the public Internet, these headers will afford us this behavior:

If someone uses **Reply**, the email address of the user who sent the message will be in the _To_ field ("off list"). If someone uses **Reply All**, the email address of the user who sent the message will be in the _To_ field and the address in the _List-Post_ header will be CC'd (posted to Community).

We no longer set a _Reply-To_ field.
