### PR TITLE
Update images in posts to not overflow

### DIFF
--- a/app/assets/stylesheets/post.css.scss
+++ b/app/assets/stylesheets/post.css.scss
@@ -32,6 +32,9 @@
     ul, ol {
       margin: 10px 0;
     }
+    img {
+      max-width: 100%;
+    }
   }
 
   // Smaller than a medium screen


### PR DESCRIPTION
Previously, very wide images would overflow the width of posts, making a post with a large image unreadable. This updates images in posts so that they stay a sane size.

Screenshot of the problem:

![screen shot 2014-09-07 at 3 15 42 pm](https://cloud.githubusercontent.com/assets/1976330/4179914/8a6d708a-36dc-11e4-8587-4b7eba90145b.png)

:smile_cat: 
