### PR TITLE
Include List-Id email header

### DIFF
--- a/app/controllers/concerns/email_fields.rb
+++ b/app/controllers/concerns/email_fields.rb
@@ -12,4 +12,8 @@ module EmailFields
   def subforum_thread_subject(thread)
     "[Community - #{thread.subforum.name}] #{thread.title}"
   end
+
+  def list_id(subforum)
+    "<#{subforum.name.downcase.gsub(/\s+/, '-')}.community.hackerschool.com>"
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -17,11 +17,11 @@ class NotificationMailer < ActionMailer::Base
     end
 
     mail(message_id: @post.message_id,
-         to: list_address(@post.thread.subforum),
-         bcc: @user.email,
+         to: @user.email,
          from: @mentioned_by.display_email,
          reply_to: reply_to_post_address(reply_info),
-         subject: subforum_thread_subject(@post.thread))
+         subject: subforum_thread_subject(@post.thread),
+         "List-Id" => list_id(@post.thread.subforum))
   end
 
   def broadcast_email(user_ids, post)
@@ -37,7 +37,8 @@ class NotificationMailer < ActionMailer::Base
          to: list_address(@post.thread.subforum),
          bcc: users.map(&:email),
          from: @post.author.display_email,
-         subject: subforum_thread_subject(@post.thread))
+         subject: subforum_thread_subject(@post.thread),
+         "List-Id" => list_id(@post.thread.subforum))
   end
 
   def new_post_in_subscribed_thread_email(user_ids, post)
@@ -52,7 +53,8 @@ class NotificationMailer < ActionMailer::Base
          to: list_address(@post.thread.subforum),
          bcc: users.map(&:email),
          from: @post.author.display_email,
-         subject: subforum_thread_subject(@post.thread))
+         subject: subforum_thread_subject(@post.thread),
+         "List-Id" => list_id(@post.thread.subforum))
   end
 
   def new_thread_in_subscribed_subforum_email(user_ids, thread)
@@ -72,6 +74,7 @@ private
          to: list_address(@thread.subforum),
          bcc: users.map(&:email),
          from: @thread.created_by.display_email,
-         subject: subforum_thread_subject(@thread))
+         subject: subforum_thread_subject(@thread),
+         "List-Id" => list_id(@thread.subforum))
   end
 end

--- a/app/services/batch_mail_sender.rb
+++ b/app/services/batch_mail_sender.rb
@@ -43,6 +43,7 @@ private
       "html" => mail.html_part.body.to_s,
       "h:Message-ID" => mail.header["Message-ID"].to_s,
       "h:In-Reply-To" => mail.header["In-Reply-To"].to_s,
+      "h:List-Id" => mail.header["List-Id"].to_s,
       "h:Reply-To" => reply_to_post_address("%recipient.reply_info%"),
       "v:reply_info" => "%recipient.reply_info%",
       "recipient-variables" => JSON.generate(recipient_variables))


### PR DESCRIPTION
This allows you to filter all messages sent from Community using the following:

```
listid: *.community.hackerschool.com
```
