### PR TITLE
Break long words in posts (e.g. links with long components)

### DIFF
--- a/app/assets/stylesheets/post.css.scss
+++ b/app/assets/stylesheets/post.css.scss
@@ -2,6 +2,7 @@
   margin: .5em 0;
   padding: .5em 0;
   border-top: 1px dotted #bbb;
+  word-break: break-word;
 
   .post-author-image {
     @include make-sm-column(1);


### PR DESCRIPTION
Fixes #229.
