### PR TITLE
Connect to redis lazily instead of on worker boot (Fixes #266)

### DIFF
--- a/app/services/distributed_lock.rb
+++ b/app/services/distributed_lock.rb
@@ -20,7 +20,7 @@
 class DistributedLock
   def initialize(key)
     @key = key
-    @redis = $redis
+    @redis = RedisCache.redis
   end
 
   def synchronize

--- a/app/services/pub_sub.rb
+++ b/app/services/pub_sub.rb
@@ -148,7 +148,7 @@ private
     def publish
       json = JSON.dump(emitter: emitter, event: event, feed: feed, id: resource.id)
 
-      $redis.publish :pubsub, json
+      RedisCache.redis.publish :pubsub, json
     end
 
     def feed

--- a/app/services/redis_cache.rb
+++ b/app/services/redis_cache.rb
@@ -1,0 +1,10 @@
+class RedisCache
+  def self.redis
+    if defined? @redis
+      return @redis
+    end
+
+    uri = URI.parse(ENV["REDIS_URL"])
+    @redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
+  end
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,4 @@ on_worker_boot do
     config['reaping_frequency'] = 8
     ActiveRecord::Base.establish_connection(config)
   end
-
-  uri = URI.parse(ENV["REDIS_URL"])
-  $redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 end

--- a/test/services/distributed_lock_test.rb
+++ b/test/services/distributed_lock_test.rb
@@ -19,7 +19,7 @@ class DistributedLockTest < ActiveSupport::TestCase
   end
 
   test "cleans up stale values" do
-    $redis.set(:test_distributed_lock, Time.now.to_i - 1)
+    RedisCache.redis.set(:test_distributed_lock, Time.now.to_i - 1)
 
     start = Time.now
     DistributedLock.new(:test_distributed_lock).synchronize do

--- a/test/services/redis_cache.rb
+++ b/test/services/redis_cache.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RedisCacheTest < ActiveSupport::TestCase
+  test "connects to redis" do
+    assert_not RedisCache.redis, nil
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,6 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 ENV['MAILGUN_API_KEY'] = "foobarbaz"
-uri = URI.parse(ENV["REDIS_URL"])
-$redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
`@mentions` broke when we started sending notifications in a job. The problem was that `$redis` was defined in puma's `on_worker_boot`, which isn't run for the job worker. This fix lazily connects to redis and caches the connection instead of relying on a global.
