### PR TITLE
nicer spinner animation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     faye-websocket (0.9.2)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    font-awesome-sass (4.2.1)
+    font-awesome-sass (4.6.2)
       sass (~> 3.2)
     globalid (0.3.6)
       activesupport (>= 4.1.0)

--- a/client/src/community/partials.cljs
+++ b/client/src/community/partials.cljs
@@ -58,7 +58,7 @@
 (defn loading-icon [color]
   (html
     [:div.push-down.loading
-     [:i.fa.fa-spinner.fa-spin.fa-2x {:style {:color color}}]]))
+     [:i.fa.fa-spinner.fa-pulse.fa-2x {:style {:color color}}]]))
 
 (defn wrap-mentions
   "Wraps @mentions in a post body in <span class=\"at-mention\">"


### PR DESCRIPTION
Hello! the font awesome spinner Community uses is 8-fold symmetrical, and has a pretty nice illusion of movement when it's rotated step-wise instead of continuously (which looks kind of strange). This change just means using font awesome's fa-pulse class instead of spin. Cut and dry, except that it also means bumping our font awesome version from 4.2.1 to the latest, 4.6.2*. 

Caveat: I'm currently on a train, and can't install all of the dependencies to actually test this. it should just work, but I would really appreciate if someone could check it out and give me a thumbs up :sheep: 

The difference between spin and pulse is demonstrated here:
http://fontawesome.io/examples/#animated

pulse was introduced in version 4.3.0
https://github.com/FortAwesome/Font-Awesome/commit/89a28f8b1f9882159dce581ee92d398bbc33ad59

*and font awesome follows semver, so this should ~theoretically~  not break anything!:
https://github.com/FortAwesome/Font-Awesome#versioning

https://rubygems.org/gems/font-awesome-sass/versions

Another solution would be to switch to another spinner that doesn't rely on this illusion, like fa-cog 
