### PR TITLE
Prepare for elasticsearch 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,6 @@ gem 'bulk_insert'
 
 gem 'thread_safe'
 
-gem 'elasticsearch'
+gem 'elasticsearch', '~> 2.0'
 gem 'elasticsearch-model'
 gem 'elasticsearch-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,17 +63,17 @@ GEM
     dotenv (2.0.0)
     dotenv-rails (2.0.0)
       dotenv (= 2.0.0)
-    elasticsearch (1.0.8)
-      elasticsearch-api (= 1.0.7)
-      elasticsearch-transport (= 1.0.7)
-    elasticsearch-api (1.0.7)
+    elasticsearch (2.0.1)
+      elasticsearch-api (= 2.0.1)
+      elasticsearch-transport (= 2.0.1)
+    elasticsearch-api (2.0.1)
       multi_json
     elasticsearch-model (0.1.6)
       activesupport (> 3)
       elasticsearch (> 0.4)
       hashie
     elasticsearch-rails (0.1.6)
-    elasticsearch-transport (1.0.7)
+    elasticsearch-transport (2.0.1)
       faraday
       multi_json
     em-pg-client (0.3.4)
@@ -82,7 +82,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.4.0)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faye-websocket (0.9.2)
       eventmachine (>= 0.12.0)
@@ -232,7 +232,7 @@ DEPENDENCIES
   dalli
   delayed_job_active_record
   dotenv-rails
-  elasticsearch
+  elasticsearch (~> 2.0)
   elasticsearch-model
   elasticsearch-rails
   em-pg-client
@@ -266,4 +266,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -13,7 +13,7 @@ module Searchable
     # Configure index to serve completion suggestions.
     settings index: {number_of_shards: 1} do
       mappings dynamic: 'true' do
-        indexes :suggest, type: :completion, index_analyzer: :whitespace, search_analyzer: :whitespace, payloads: true
+        indexes :suggest, type: :completion, analyzer: :whitespace, search_analyzer: :whitespace, payloads: true
       end
     end
   end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,3 +1,3 @@
-ENV['ELASTICSEARCH_URL'] ||= ENV['BONSAI_URL'] || 'http://localhost:9200'
+ENV['ELASTICSEARCH_URL'] ||= ENV['BONSAI_IVORY_URL'] || 'http://localhost:9200'
 
 Elasticsearch::Model.client = Elasticsearch::Client.new log: Rails.env.development?


### PR DESCRIPTION
Steps already taken:

* Locally tested reindexing, searching, and suggesting results on elasticsearch 2.4
* Provisioned a new Bonsai elasticsearch cluster (`BONSAI_IVORY_URL`)

Steps to upgrade after deploy:

* Run `heroku run bin/rake search:rebuild` to rebuild index in newly provisioned cluster (we don't have so much data that we have to migrate it—we can just rebuild from scratch)
* Test suggestions & search on production
* Remove old cluster (`BONSAI_URL`)