### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ brew install leiningen redis elasticsearch
 # If you don't already have caskroom:
 $ brew install caskroom/cask/brew-cask
 # And then:
-$ brew cask install java
+$ brew install --cask java
 $ brew install elasticsearch
 ```
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524