### PR TITLE
Downgrade to Puma 5.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :development, :test do
 end
 
 # Use puma as the app server
-gem 'puma'
+gem 'puma', '~> 5.6'
 gem 'faye-websocket'
 gem 'eventmachine'
 gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
-    puma (6.0.2)
+    puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.2)
@@ -297,7 +297,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   pry-remote
-  puma
+  puma (~> 5.6)
   rack-timeout
   rails (= 5.2.8.1)
   redcarpet


### PR DESCRIPTION
I don't have hard evidence, but I wonder if the upgrade from Puma 5.6 to Puma 6 has caused the [ThreadErrors that we're seeing](https://recurse-corp.zulipchat.com/#narrow/stream/16906-dev/topic/memory.20and.20threading.20issues.20in.20virtual.20rc) in Virtual RC and Community.

Going to downgrade and see what happens.