### PR TITLE
Enable Heroku Ruby Language Metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'delayed_job_active_record'
 # gem 'skylight'
 gem 'airbrake'
 
+# https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
+gem 'barnes'
+
 # Use SCSS for stylesheets
 gem 'sass-rails'
 gem 'bootstrap-sass', '~> 3.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.6.0)
       execjs
+    barnes (0.0.9)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     bindex (0.8.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -247,6 +250,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.5.0)
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -270,6 +274,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake
+  barnes
   bootsnap
   bootstrap-sass (~> 3.4.1)
   bulk_insert

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,6 +33,12 @@ preload_app!
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
+# https://devcenter.heroku.com/articles/language-runtime-metrics-ruby
+require 'barnes'
+before_fork do
+  Barnes.start
+end
+
 on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     Rails.logger.error "Worker booted. #{ConnectionMonitor::CONNECTIONS.size} checked out connections."


### PR DESCRIPTION
Non-code change: adding the `heroku/metrics` buildpack. See the [Ruby Language Metrics docs](https://devcenter.heroku.com/articles/language-runtime-metrics-ruby) for more.