### PR TITLE
Downgrade mail to 2.7.1 to see if that fixes the timeout errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.6.10'
 gem 'rails', '5.2.8.1'
 gem 'pg'
 
+# Remove this when we upgrade to Ruby 3.1 or later.
 gem 'mail', '~> 2.7.1'
 
 gem 'bootsnap', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ ruby '2.6.10'
 gem 'rails', '5.2.8.1'
 gem 'pg'
 
+gem 'mail', '~> 2.7.1'
+
 gem 'bootsnap', require: false
 
 gem 'redis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
     connection_pool (2.3.0)
     crass (1.0.6)
     dalli (2.7.10)
-    date (3.3.3)
     delayed_job (4.1.7)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -136,11 +135,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0.1)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     memcachier (0.0.2)
     method_source (0.9.2)
@@ -151,15 +147,6 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    net-imap (0.3.4)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
-    net-protocol (0.2.1)
-      timeout
-    net-smtp (0.3.3)
-      net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -254,7 +241,6 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timeout (0.3.1)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -294,6 +280,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   listen
+  mail (~> 2.7.1)
   memcachier
   minitest-ci!
   oauth2


### PR DESCRIPTION
Mail 2.8 depends on the net-imap, net-smtp, and net-pop gems, which were extracted from the standard library in Ruby 3.1.

Timeout has been causing us issues (even though Mail 2.7 is still using it in the standard library version), and I’m curious to see if this fixes the problem.