### PR TITLE
Prep for moving away from EventMachineSMTPDelivery

### DIFF
--- a/app/controllers/api/private/email_webhooks_controller.rb
+++ b/app/controllers/api/private/email_webhooks_controller.rb
@@ -2,20 +2,18 @@ require 'openssl'
 
 class Api::Private::EmailWebhooksController < Api::ApiController
   before_action :require_mailgun_origin
-  before_action :require_valid_reply_info
   skip_before_action :require_login
   skip_before_action :verify_authenticity_token
   skip_authorization_check
 
   # Mailgun will POST to this endpoint when someone replies to an
-  # email with a reply-to of the form:
+  # email with a reply-to of the forms:
   #
   #     reply-(reply_info)@mail.community.recurse.com
+  #     subforum-name@lists.community.recurse.com
   #
   # important params:
   #
-  #     reply_info, a Base64 encoded and signed string that can be
-  #       verified with ReplyInfoVerifier.verify
   #     stripped-text, the plain-text email body, not including a
   #       signature or trailing quoted text
   #     timestamp, token, signature, used to verify that the POST
@@ -27,6 +25,13 @@ class Api::Private::EmailWebhooksController < Api::ApiController
   # For any other code, Mailgun will retry the POST on an increasing
   # interval over the next 8 hours.
   def reply
+    current_user = User.find_by(email: params["sender"])
+    emailed_post = Post.find_by(message_id: params["In-Reply-To"])
+
+    unless current_user.present? && emailed_post.present?
+      head 406 and return
+    end
+
     post = emailed_post.thread.posts.build
 
     unless can?(:create, post)
@@ -51,8 +56,10 @@ class Api::Private::EmailWebhooksController < Api::ApiController
   end
 
   def opened
-    # Skip unless we have a v2 reply info
-    if !params['reply_info'].start_with?("v2--")
+    current_user = User.find_by(email: params["recipient"])
+    emailed_post = Post.find_by(message_id: params["message-id"])
+
+    unless current_user.present? && emailed_post.present?
       head 406 and return
     end
 
@@ -62,26 +69,6 @@ class Api::Private::EmailWebhooksController < Api::ApiController
   end
 
 private
-  def reply_info
-    @reply_info ||= begin
-      ReplyInfoVerifier.verify(params['reply_info'])
-    rescue ReplyInfoVerifier::InvalidSignature, ActiveRecord::RecordNotFound => e
-      nil
-    end
-  end
-
-  def valid_reply_info?
-    !reply_info.nil?
-  end
-
-  def current_user
-    reply_info[0]
-  end
-
-  def emailed_post
-    reply_info[1]
-  end
-
   def require_mailgun_origin
     api_key = ENV["MAILGUN_API_KEY"]
     digest = OpenSSL::Digest::SHA256.new
@@ -89,12 +76,6 @@ private
 
     unless SecureEquals.secure_equals(params[:signature], OpenSSL::HMAC.hexdigest(digest, api_key, data))
       head 404
-    end
-  end
-
-  def require_valid_reply_info
-    unless valid_reply_info?
-      head 406
     end
   end
 end

--- a/app/controllers/api/private/email_webhooks_controller.rb
+++ b/app/controllers/api/private/email_webhooks_controller.rb
@@ -1,6 +1,6 @@
 require 'openssl'
 
-class Api::Private::LegacyEmailWebhooksController < Api::ApiController
+class Api::Private::EmailWebhooksController < Api::ApiController
   before_action :require_mailgun_origin
   before_action :require_valid_reply_info
   skip_before_action :require_login

--- a/app/controllers/api/private/email_webhooks_controller.rb
+++ b/app/controllers/api/private/email_webhooks_controller.rb
@@ -38,6 +38,8 @@ class Api::Private::EmailWebhooksController < Api::ApiController
       head 406 and return
     end
 
+    Rails.logger.info "Mailgun spam headers: X-Mailgun-Sflag=#{params["X-Mailgun-Sflag"]} X-Mailgun-Sscore=#{params["X-Mailgun-Sscore"]} X-Mailgun-Spf=#{params["X-Mailgun-Spf"]} X-Mailgun-Dkim-Check-Result=#{params["X-Mailgun-Dkim-Check-Result"]}"
+
     post.author = current_user
     post.body = params['stripped-text']
     post.message_id = params["Message-Id"]

--- a/app/controllers/api/private/email_webhooks_controller.rb
+++ b/app/controllers/api/private/email_webhooks_controller.rb
@@ -34,7 +34,7 @@ class Api::Private::EmailWebhooksController < Api::ApiController
 
     post = emailed_post.thread.posts.build
 
-    unless can?(:create, post)
+    unless Ability.new(current_user).can?(:create, post)
       head 406 and return
     end
 

--- a/app/controllers/api/private/legacy_email_webhooks_controller.rb
+++ b/app/controllers/api/private/legacy_email_webhooks_controller.rb
@@ -1,6 +1,6 @@
 require 'openssl'
 
-class Api::Private::EmailWebhooksController < Api::ApiController
+class Api::Private::LegacyEmailWebhooksController < Api::ApiController
   before_action :require_mailgun_origin
   before_action :require_valid_reply_info
   skip_before_action :require_login

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -60,7 +60,7 @@ private
       "List-Id" => list_id(post.thread.subforum),
       "List-Archive" => list_archive(post.thread),
       "List-Post" => list_post(@reply_info),
-      "List-Unsubscribe" => list_unsubscribe(@reply_info),
+      "List-Unsubscribe" => list_unsubscribe(post.thread),
 
       # Mailgun sends these back to us when users reply to a sent email
       "X-Mailgun-Variables" => {reply_info: @reply_info}.to_json
@@ -96,7 +96,7 @@ private
     "<mailto:#{reply_to_post_address(reply_info)}>"
   end
 
-  def list_unsubscribe(reply_info)
-    "<#{unsubscribe_thread_url(reply_info)}>"
+  def list_unsubscribe(thread)
+    "<#{unsubscribe_thread_url(thread)}>"
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,38 +12,32 @@ class NotificationMailer < ActionMailer::Base
   end
 
   def broadcast_email(user, post)
-    @user = user
     @post = post
     @group_names = post.broadcast_groups.map(&:name)
 
-    make_mail(@user, @post)
+    make_mail(user, @post)
   end
 
   def new_post_in_subscribed_thread_email(user, post)
-    @user = user
     @post = post
 
-    make_mail(@user, @post)
+    make_mail(user, @post)
   end
 
   def new_thread_in_subscribed_subforum_email(user, thread)
-    @user = user
     @thread = thread
 
-    make_mail(@user, @thread.posts.first)
+    make_mail(user, @thread.posts.first)
   end
 
   def new_subscribed_thread_in_subscribed_subforum_email(user, thread)
-    @user = user
     @thread = thread
 
-    make_mail(@user, @thread.posts.first)
+    make_mail(user, @thread.posts.first)
   end
 
 private
   def make_mail(user, post)
-    @reply_info = ReplyInfoVerifier.generate(user, post)
-
     if post.previous_message_id
       headers["References"] = headers["In-Reply-To"] = post.previous_message_id
     end
@@ -54,30 +48,19 @@ private
       to: list_address(post.thread.subforum),
       from: post.author.display_email,
       subject: subforum_thread_subject(post.thread),
-      reply_to: reply_to(@reply_info),
+      reply_to: list_address(post.thread.subforum),
 
       "Precedence" => "list",
       "List-Id" => list_id(post.thread.subforum),
       "List-Archive" => list_archive(post.thread),
-      "List-Post" => list_post(@reply_info),
+      "List-Post" => list_post(post.thread.subforum),
       "List-Unsubscribe" => list_unsubscribe(post.thread),
-
-      # Mailgun sends these back to us when users reply to a sent email
-      "X-Mailgun-Variables" => {reply_info: @reply_info}.to_json
     )
   end
 
 private
   def subforum_thread_subject(thread)
     "[Community - #{thread.subforum.name}] #{thread.title}"
-  end
-
-  def reply_to(reply_info)
-    "Community <#{reply_to_post_address(reply_info)}>"
-  end
-
-  def reply_to_post_address(reply_info)
-    "reply-#{reply_info}@mail.community.recurse.com"
   end
 
   def list_address(subforum)
@@ -92,8 +75,8 @@ private
     thread_url(id: thread.id, slug: thread.slug)
   end
 
-  def list_post(reply_info)
-    "<mailto:#{reply_to_post_address(reply_info)}>"
+  def list_post(subforum)
+    "<mailto:#{list_address(subforum)}>"
   end
 
   def list_unsubscribe(thread)

--- a/app/views/notification_mailer/broadcast_email.html.erb
+++ b/app/views/notification_mailer/broadcast_email.html.erb
@@ -3,9 +3,7 @@
 <div style="border-top: 1px solid #ccc;">
   <p><%= @post.author.name %> broadcast this message to <%= @group_names.to_sentence %>.</p>
 
-  <% unless @user.subscribed_to?(@post.thread) %>
-    <p><%= link_to "Subscribe to this thread.", subscribe_thread_url(@reply_info) %></p>
-  <% end %>
+  <p><%= link_to "Subscribe to this thread.", subscribe_thread_url(@post.thread) %></p>
 
   <p>Reply to this email or <%= link_to "view the post on Community", post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>.</p>
 </div>

--- a/app/views/notification_mailer/broadcast_email.text.erb
+++ b/app/views/notification_mailer/broadcast_email.text.erb
@@ -2,9 +2,7 @@
 
 ---
 <%= @post.author.name %> broadcast this message to <%= @group_names.to_sentence %>.
-<% unless @user.subscribed_to?(@post.thread) %>
 
-Subscribe to this thread: <%= subscribe_thread_url(@reply_info) %>
-<% end %>
+Subscribe to this thread: <%= subscribe_thread_url(@post.thread) %>
 
 Reply to this email or view the post on Community: <%= post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>

--- a/app/views/notification_mailer/new_post_in_subscribed_thread_email.html.erb
+++ b/app/views/notification_mailer/new_post_in_subscribed_thread_email.html.erb
@@ -3,7 +3,7 @@
 <div style="border-top: 1px solid #ccc;">
   <p>
     You received this message because you are subscribed to this thread.
-    <%= link_to "Unsubscribe.", unsubscribe_thread_url(token: @post.thread) %>
+    <%= link_to "Unsubscribe.", unsubscribe_thread_url(@post.thread) %>
   </p>
   <p>Reply to this email or <%= link_to "view the post on Community", post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>.</p>
 </div>

--- a/app/views/notification_mailer/new_post_in_subscribed_thread_email.html.erb
+++ b/app/views/notification_mailer/new_post_in_subscribed_thread_email.html.erb
@@ -3,7 +3,7 @@
 <div style="border-top: 1px solid #ccc;">
   <p>
     You received this message because you are subscribed to this thread.
-    <%= link_to "Unsubscribe.", unsubscribe_thread_url(token: @reply_info) %>
+    <%= link_to "Unsubscribe.", unsubscribe_thread_url(token: @post.thread) %>
   </p>
   <p>Reply to this email or <%= link_to "view the post on Community", post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>.</p>
 </div>

--- a/app/views/notification_mailer/new_post_in_subscribed_thread_email.text.erb
+++ b/app/views/notification_mailer/new_post_in_subscribed_thread_email.text.erb
@@ -1,6 +1,6 @@
 <%= @post.body %>
 
 ---
-You received this message because you are subscribed to this thread. Unsubscribe from this thread: <%= unsubscribe_thread_url(token: @reply_info) %>
+You received this message because you are subscribed to this thread. Unsubscribe from this thread: <%= unsubscribe_thread_url(@post.thread) %>
 
 Reply to this email or view the post on Community: <%= post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>

--- a/app/views/notification_mailer/new_subscribed_thread_in_subscribed_subforum_email.html.erb
+++ b/app/views/notification_mailer/new_subscribed_thread_in_subscribed_subforum_email.html.erb
@@ -3,7 +3,7 @@
 <div style="border-top: 1px solid #ccc;">
   <p>
     You received this message because you are subscribed to the subforum "<%= @thread.subforum.name %>."
-    <%= link_to "Unsubscribe from this thread.", unsubscribe_thread_url(token: @reply_info) %>
+    <%= link_to "Unsubscribe from this thread.", unsubscribe_thread_url(@thread) %>
   </p>
   <p>Reply to this email or <%= link_to "view the thread on Community", thread_url(slug: @thread.slug, id: @thread.id) %>.</p>
 </div>

--- a/app/views/notification_mailer/new_subscribed_thread_in_subscribed_subforum_email.text.erb
+++ b/app/views/notification_mailer/new_subscribed_thread_in_subscribed_subforum_email.text.erb
@@ -1,6 +1,6 @@
 <%= @thread.posts.first.body %>
 
 ---
-You received this message because you are subscribed to the subforum "<%= @thread.subforum.name %>." Unsubscribe from this thread: <%= unsubscribe_thread_url(token: @reply_info) %>
+You received this message because you are subscribed to the subforum "<%= @thread.subforum.name %>." Unsubscribe from this thread: <%= unsubscribe_thread_url(@thread) %>
 
 Reply to this email or view the thread on Community: <%= thread_url(slug: @thread.slug, id: @thread.id) %>

--- a/app/views/notification_mailer/new_thread_in_subscribed_subforum_email.html.erb
+++ b/app/views/notification_mailer/new_thread_in_subscribed_subforum_email.html.erb
@@ -3,7 +3,7 @@
 <div style="border-top: 1px solid #ccc;">
   <p>
     You received this message because you are subscribed to the subforum "<%= @thread.subforum.name %>."
-    <%= link_to "Subscribe to this thread.", subscribe_thread_url(token: @reply_info) %>
+    <%= link_to "Subscribe to this thread.", subscribe_thread_url(@thread) %>
   </p>
   <p>Reply to this email or <%= link_to "view the thread on Community", thread_url(slug: @thread.slug, id: @thread.id) %>.</p>
 </div>

--- a/app/views/notification_mailer/new_thread_in_subscribed_subforum_email.text.erb
+++ b/app/views/notification_mailer/new_thread_in_subscribed_subforum_email.text.erb
@@ -1,6 +1,6 @@
 <%= @thread.posts.first.body %>
 
 ---
-You received this message because you are subscribed to the subforum "<%= @thread.subforum.name %>." Subscribe to this thread: <%= subscribe_thread_url(token: @reply_info) %>
+You received this message because you are subscribed to the subforum "<%= @thread.subforum.name %>." Subscribe to this thread: <%= subscribe_thread_url(@thread) %>
 
 Reply to this email or view the thread on Community: <%= thread_url(slug: @thread.slug, id: @thread.id) %>

--- a/app/views/notification_mailer/user_mentioned_email.html.erb
+++ b/app/views/notification_mailer/user_mentioned_email.html.erb
@@ -4,7 +4,7 @@
   <p>You received this message because <%= @mentioned_by.first_name %> mentioned you in the post above.</p>
 
   <% unless @user.subscribed_to?(@post.thread) %>
-    <p><%= link_to "Subscribe to this thread.", subscribe_thread_url(@reply_info) %></p>
+    <p><%= link_to "Subscribe to this thread.", subscribe_thread_url(@post.thread) %></p>
   <% end %>
 
   <p>Reply to this email or <%= link_to "view the post on Community", post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>.</p>

--- a/app/views/notification_mailer/user_mentioned_email.text.erb
+++ b/app/views/notification_mailer/user_mentioned_email.text.erb
@@ -4,7 +4,7 @@
 You received this message because <%= @mentioned_by.first_name %> mentioned you in the post above.
 <% unless @user.subscribed_to?(@post.thread) %>
 
-Subscribe to this thread: <%= subscribe_thread_url(@reply_info) %>
+Subscribe to this thread: <%= subscribe_thread_url(@post.thread) %>
 <% end %>
 
 Reply to this email or view the post on Community: <%= post_url(slug: @post.thread.slug, thread_id: @post.thread.id, post_number: @post.post_number) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,11 @@ Rails.application.routes.draw do
     end
 
     namespace :private do
-      post :reply, to: 'email_webhooks#reply'
-      post :opened, to: 'email_webhooks#opened'
+      post :reply, to: 'legacy_email_webhooks#reply'
+      post :opened, to: 'legacy_email_webhooks#opened'
+
+      post :reply_legacy, to: 'legacy_email_webhooks#reply'
+      post :opened_legacy, to: 'legacy_email_webhooks#opened'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,11 +61,8 @@ Rails.application.routes.draw do
     end
 
     namespace :private do
-      post :reply, to: 'legacy_email_webhooks#reply'
-      post :opened, to: 'legacy_email_webhooks#opened'
-
-      post :reply_legacy, to: 'legacy_email_webhooks#reply'
-      post :opened_legacy, to: 'legacy_email_webhooks#opened'
+      post :reply, to: 'email_webhooks#reply'
+      post :opened, to: 'email_webhooks#opened'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,9 @@ Rails.application.routes.draw do
 
     namespace :private do
       post :reply, to: 'email_webhooks#reply'
+      post :reply_legacy, to: 'email_webhooks#reply'
       post :opened, to: 'email_webhooks#opened'
+      post :opened_legacy, to: 'email_webhooks#opened'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,9 +62,7 @@ Rails.application.routes.draw do
 
     namespace :private do
       post :reply, to: 'email_webhooks#reply'
-      post :reply_legacy, to: 'email_webhooks#reply'
       post :opened, to: 'email_webhooks#opened'
-      post :opened_legacy, to: 'email_webhooks#opened'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,10 @@ Rails.application.routes.draw do
   get '/s', to: 'pages#index'
   get '/s/:query', to: 'pages#index'
 
-  get '/threads/:id/unsubscribe', to: 'threads#unsubscribe'
-  get '/threads/:id/subscribe', to: 'threads#subscribe'
-  get '/threads/unsubscribe/:token', to: 'threads#unsubscribe_with_reply_info', as: :unsubscribe_thread
-  get '/threads/subscribe/:token', to: 'threads#subscribe_with_reply_info', as: :subscribe_thread
+  get '/threads/:id/unsubscribe', to: 'threads#unsubscribe', as: :unsubscribe_thread
+  get '/threads/:id/subscribe', to: 'threads#subscribe', as: :subscribe_thread
+  get '/threads/unsubscribe/:token', to: 'threads#unsubscribe_with_reply_info'
+  get '/threads/subscribe/:token', to: 'threads#subscribe_with_reply_info'
 
   # sudo for development only
   namespace :admin do

--- a/test/controllers/api/private/email_webhooks_controller_test.rb
+++ b/test/controllers/api/private/email_webhooks_controller_test.rb
@@ -1,14 +1,14 @@
 require 'test_helper'
 
 class Api::Private::EmailWebhooksControllerTest < ActionController::TestCase
-  def setup
-    @reply_info = ReplyInfoVerifier.generate(users(:dave), posts(:zach_post_1))
-  end
-
   test "valid email reply" do
+    dave = users(:dave)
+    p = posts(:zach_post_1)
+
     assert_difference('Post.count', +1) do
       post :reply, params: mailgun_origin_params.merge({
-        reply_info: @reply_info,
+        "In-Reply-To" => p.message_id,
+        "sender" => dave.email,
         "stripped-text" => "This is my reply"
       })
       assert_response :success
@@ -16,37 +16,48 @@ class Api::Private::EmailWebhooksControllerTest < ActionController::TestCase
   end
 
   test "email reply not from mailgun origin" do
-    post :reply, params: {reply_info: @reply_info, "stripped-text" => "This is my reply"}
+    dave = users(:dave)
+    p = posts(:zach_post_1)
+
+    post :reply, params: {
+      "In-Reply-To" => p.message_id,
+      "sender" => dave.email,
+      "stripped-text" => "This is my reply"
+    }
     assert_response :not_found
   end
 
-  test "email reply with bad reply_info" do
-    post :reply, params: mailgun_origin_params.merge({
-      reply_info: @reply_info[0...-1],
-      "stripped-text" => "This is my reply"
-    })
-    assert_response 406
-  end
-
   test "email opened updates visited status" do
-    visited_status = VisitedStatus.where(user: users(:dave), thread: posts(:zach_post_1).thread).first_or_create
+    dave = users(:dave)
+    p = posts(:zach_post_1)
+
+    visited_status = VisitedStatus.where(user: dave, thread: p.thread).first_or_create
 
     visited_status.update(last_post_number_read: 0)
 
-    post :opened, params: mailgun_origin_params.merge({reply_info: @reply_info})
+    post :opened, params: mailgun_origin_params.merge({
+      "message-id" => p.message_id,
+      "recipient" => dave.email,
+    })
     assert_response :success
 
     visited_status.reload
 
-    assert_equal visited_status.last_post_number_read, posts(:zach_post_1).post_number
+    assert_equal visited_status.last_post_number_read, p.post_number
   end
 
   test "email opened doesn't update visited status if the thread has been visited since the post was made" do
-    visited_status = VisitedStatus.where(user: users(:dave), thread: posts(:zach_post_1).thread).first_or_create
+    dave = users(:dave)
+    p = posts(:zach_post_1)
+
+    visited_status = VisitedStatus.where(user: dave, thread: p.thread).first_or_create
 
     visited_status.update(last_post_number_read: posts(:zach_post_1).post_number + 1)
 
-    post :opened, params: mailgun_origin_params.merge({reply_info: @reply_info})
+    post :opened, params: mailgun_origin_params.merge({
+      "message-id" => p.message_id,
+      "recipient" => dave.email,
+    })
     assert_response 200
 
     visited_status.reload
@@ -55,11 +66,17 @@ class Api::Private::EmailWebhooksControllerTest < ActionController::TestCase
   end
 
   test "email opened doesn't update visited status if the thread has been destroyed" do
-    visited_status = VisitedStatus.where(user: users(:dave), thread: posts(:zach_post_1).thread).first_or_create
+    dave = users(:dave)
+    p = posts(:zach_post_1)
+
+    visited_status = VisitedStatus.where(user: dave, thread: p.thread).first_or_create
 
     posts(:zach_post_1).thread.destroy
 
-    post :opened, params: mailgun_origin_params.merge({reply_info: @reply_info})
+    post :opened, params: mailgun_origin_params.merge({
+      "message-id" => p.message_id,
+      "recipient" => dave.email,
+    })
     assert_response 406
   end
 

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -5,21 +5,25 @@ zach_post_1:
   thread: one
   author: zach
   post_number: 1
+  message_id: <zach_post_1@example.com>
 
 dave_post_1:
   body: Some other stuff
   thread: one
   author: dave
   post_number: 2
+  message_id: <dave_post_1@example.com>
 
 first_in_thread_created_by_full_hacker_schooler:
   body: a post body
   thread_id: 1
   author: full_hacker_schooler
   post_number: 1
+  message_id: <first_in_thread_created_by_full_hacker_schooler@example.com>
 
 second_in_thread_created_by_full_hacker_schooler:
   body: a post body
   thread_id: 1
   author: full_hacker_schooler
   post_number: 2
+  message_id: <second_in_thread_created_by_full_hacker_schooler@example.com>


### PR DESCRIPTION
- Remove user-specific `reply_info` from subscribe and unsubscribe links in emails
- The "unsubscribe" and "subscribe" links in emails now require you to be logged in. Hopefully this doesn't annoy people.