### PR TITLE
Rails 6 odds and ends

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/rails server
 worker: bin/rails jobs:work
+release: bin/rails db:migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,9 +48,9 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = {hsts: {subdomains: true}}
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/lib/tasks/cljs.rake
+++ b/lib/tasks/cljs.rake
@@ -51,5 +51,8 @@ namespace :cljs do
   end
 end
 
-# Rake::Task["assets:precompile"].enhance(["cljs:build"])
+unless ENV.key?("CLJS_SKIP_BUILD_ON_PRECOMPILE")
+  Rake::Task["assets:precompile"].enhance(["cljs:build"])
+end
+
 Rake::Task["assets:clobber"].enhance(["cljs:clobber"])


### PR DESCRIPTION
- Automatically run migrations on deploy
- Switch log level from DEBUG to INFO in production
- Compile ClojureScript when you run `rails assets:precompile`, but not on production or CI.