### PR TITLE
Better reply behavior

### DIFF
--- a/app/controllers/api/private/email_webhooks_controller.rb
+++ b/app/controllers/api/private/email_webhooks_controller.rb
@@ -51,10 +51,17 @@ class Api::Private::EmailWebhooksController < Api::ApiController
     post.mark_as_visited(current_user)
     PubSub.publish :created, :post, post
 
+    exclude_emails = (parse_emails(params["To"]) + parse_emails(params["Cc"])).uniq
+
     # TODO: parse and notify @mentions as well
-    ThreadSubscriptionNotifierJob.perform_later(post)
+    ThreadSubscriptionNotifierJob.perform_later(post, exclude_emails=exclude_emails)
 
     head 200
+  end
+
+  # extracts email addresses as a list from "To", or "Cc" headers
+  def parse_emails(headers)
+    Mail::AddressList.new(headers).addresses.map(&:address)
   end
 
   def opened

--- a/app/controllers/api/private/email_webhooks_controller.rb
+++ b/app/controllers/api/private/email_webhooks_controller.rb
@@ -54,7 +54,7 @@ class Api::Private::EmailWebhooksController < Api::ApiController
     exclude_emails = (parse_emails(params["To"]) + parse_emails(params["Cc"])).uniq
 
     # TODO: parse and notify @mentions as well
-    ThreadSubscriptionNotifierJob.perform_later(post, exclude_emails=exclude_emails)
+    ThreadSubscriptionNotifierJob.perform_later(post, exclude_emails: exclude_emails)
 
     head 200
   end

--- a/app/jobs/thread_subscription_notifier_job.rb
+++ b/app/jobs/thread_subscription_notifier_job.rb
@@ -1,5 +1,5 @@
 class ThreadSubscriptionNotifierJob < ApplicationJob
-  def perform(post, exclude_emails=[])
-    ThreadSubscriptionNotifier.new(post).notify(exclude_emails=exclude_emails)
+  def perform(post, exclude_emails: [])
+    ThreadSubscriptionNotifier.new(post, exclude_emails: exclude_emails).notify
   end
 end

--- a/app/jobs/thread_subscription_notifier_job.rb
+++ b/app/jobs/thread_subscription_notifier_job.rb
@@ -1,5 +1,5 @@
 class ThreadSubscriptionNotifierJob < ApplicationJob
-  def perform(post)
-    ThreadSubscriptionNotifier.new(post).notify
+  def perform(post, exclude_emails=[])
+    ThreadSubscriptionNotifier.new(post).notify(exclude_emails=exclude_emails)
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -45,7 +45,6 @@ private
       to: list_address(post.thread.subforum),
       from: post.author.display_email,
       subject: subforum_thread_subject(post.thread),
-      reply_to: list_address(post.thread.subforum),
 
       "Precedence" => "list",
       "List-Id" => list_id(post.thread.subforum),

--- a/app/notifiers/thread_subscription_notifier.rb
+++ b/app/notifiers/thread_subscription_notifier.rb
@@ -3,11 +3,12 @@ require 'set'
 class ThreadSubscriptionNotifier < Notifier
   attr_reader :post
 
-  def initialize(post)
+  def initialize(post, exclude_emails: [])
     @post = post
+    @exclude_emails = exclude_emails
   end
 
-  def notify(email_recipients=possible_recipients, exclude_emails=[])
+  def notify(email_recipients=possible_recipients)
     unless email_recipients.empty?
       Delayed::Job.enqueue BatchNotificationJob.new(:new_post_in_subscribed_thread_email, email_recipients, post)
     end
@@ -15,11 +16,10 @@ class ThreadSubscriptionNotifier < Notifier
 
   def possible_recipients
     @possible_recipients ||= if post.broadcast_to_subscribers?
-      subscribers = post.thread.subscribers
+      subscribers = post.thread.subscribers.where.not(email: @exclude_emails)
 
       if post.created_via_email?
-        excluded_users = User.where(email: exclude_emails)
-        subscribers = subscribers.where.not(id: post.author_id + excluded_users.pluck(:id))
+        subscribers = subscribers.where.not(id: post.author)
       end
 
       subscribers.

--- a/app/notifiers/thread_subscription_notifier.rb
+++ b/app/notifiers/thread_subscription_notifier.rb
@@ -7,7 +7,7 @@ class ThreadSubscriptionNotifier < Notifier
     @post = post
   end
 
-  def notify(email_recipients=possible_recipients)
+  def notify(email_recipients=possible_recipients, exclude_emails=[])
     unless email_recipients.empty?
       Delayed::Job.enqueue BatchNotificationJob.new(:new_post_in_subscribed_thread_email, email_recipients, post)
     end
@@ -18,7 +18,8 @@ class ThreadSubscriptionNotifier < Notifier
       subscribers = post.thread.subscribers
 
       if post.created_via_email?
-        subscribers = subscribers.where.not(id: post.author)
+        excluded_users = User.where(email: exclude_emails)
+        subscribers = subscribers.where.not(id: post.author_id + excluded_users.pluck(:id))
       end
 
       subscribers.


### PR DESCRIPTION
Make community's reply-to behavior more like other mailing lists:

- Clicking "reply" just sends a reply to the OP of the message you're replying to
- Clicking "reply all" sends a message to the OP and the list.
  - On the backend, we add some logic to prevent the OP from getting the email, since it would be a duplicate (one from the replier, one from the list)

Closes https://github.com/recursecenter/community/issues/446