### PR TITLE
Security updates: resolve 29 Dependabot alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       activerecord (>= 3.2.0)
     cancancan (3.5.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
@@ -122,9 +122,10 @@ GEM
     erubi (1.13.1)
     eventmachine (1.2.7)
     execjs (2.8.1)
-    faraday (2.7.4)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-net_http (3.0.2)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
@@ -146,6 +147,7 @@ GEM
     jbuilder (2.15.0)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    json (2.20.0)
     jwt (2.7.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -182,7 +184,7 @@ GEM
     msgpack (1.6.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -192,7 +194,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -202,7 +204,10 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    oj (3.14.2)
+    oj (3.17.3)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
+    ostruct (0.6.3)
     pg (1.4.6)
     pg_search (2.3.6)
       activerecord (>= 5.2)
@@ -225,7 +230,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    puma (6.5.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -283,7 +288,6 @@ GEM
       connection_pool
     reline (0.6.3)
       io-console (~> 0.5)
-    ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -333,7 +337,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.43)
+    yard (0.9.44)
     zeitwerk (2.8.2)
 
 PLATFORMS

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -28,7 +28,9 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+# Bind explicitly to IPv4: Puma 8 defaults to IPv6 (`::`) when an IPv6 interface
+# is available, whereas earlier versions defaulted to `0.0.0.0`.
+port ENV.fetch("PORT", 3000), "0.0.0.0"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Addresses **29 open Dependabot alerts** across 7 gem upgrades (lockfile-only, except the puma bind pin below).

## Upgrades

| Gem | From | To | Alerts | Highest sev |
|-----|------|-----|--------|-------------|
| `oj` | 3.14.2 | 3.17.3 | 11 (#184–#194) | high |
| `nokogiri` | 1.19.3 | 1.19.4 | 8 (#195–#202) | medium |
| `puma` | 6.5.0 | 8.0.2 | 2 (#178, #179) | high |
| `faraday` | 2.7.4 | 2.14.3 | 1 (#207) | high |
| `concurrent-ruby` | 1.3.6 | 1.3.7 | 3 (#204, #205, #206) | high |
| `net-imap` | 0.6.4 | 0.6.4.1 | 3 (#180, #181, #182) | medium |
| `yard` | 0.9.43 | 0.9.44 | 1 (#208) | medium |

### Alerts resolved
- **oj** — Oj integer overflow / UAF / heap & stack buffer overflows in parse & dump (CVE-2026-54896…54903, 54500, 54502, 54592)
- **nokogiri** — OOB read in `NodeSet#[]`, multiple UAF / null-deref / NONET-bypass fixes (GHSA-5prr-v3j2-97mh and 7 others)
- **puma** — PROXY protocol v1 repeated-header acceptance & remote memory exhaustion (CVE-2026-47736, CVE-2026-47737)
- **faraday** — uncontrolled recursion in `NestedParamsEncoder` → stack-exhaustion DoS (CVE-2026-54297)
- **concurrent-ruby** — `AtomicReference#update` livelock on `Float::NAN`, ReentrantReadWriteLock overflow / wrong-thread release (CVE-2026-54904/54905/54906)
- **net-imap** — command injection via ID command & non-synchronizing literal, DoS via raw-arg validation (CVE-2026-47240/47241/47242)
- **yard** — static cache reads raw traversal paths before router sanitization (CVE-2026-49342)

## Puma 8 note
Puma 8 defaults its TCP bind host to IPv6 (`::`) when an IPv6 interface is available (previously `0.0.0.0`). To preserve existing behavior, `config/puma.rb` now pins the bind host to `0.0.0.0` (IPv4). Verified locally: puma 8.0.2 boots and listens on `http://0.0.0.0:3000`.

## Verification
- `bundle check` passes
- `bin/rails test` — 24 runs, 52 assertions, 0 failures
